### PR TITLE
Configure Jpa naming strategy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,11 +12,13 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'org.projectlombok:lombok:1.18.20'
-    compileOnly 'jakarta.servlet:jakarta.servlet-api:5.0.0'
-    runtimeOnly 'org.springframework.boot:spring-boot-starter-tomcat'
+    compileOnly    'org.projectlombok:lombok:1.18.20'
+    compileOnly    'jakarta.servlet:jakarta.servlet-api:5.0.0'
+    runtimeOnly    'org.springframework.boot:spring-boot-starter-tomcat'
     implementation 'org.springframework.boot:spring-boot-starter'
-    implementation 'org.springframework.boot:spring-boot-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 

--- a/src/main/java/com/koliving/api/config/CustomNamingStrategy.java
+++ b/src/main/java/com/koliving/api/config/CustomNamingStrategy.java
@@ -1,0 +1,22 @@
+package com.koliving.api.config;
+
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+
+public class CustomNamingStrategy extends PhysicalNamingStrategyStandardImpl {
+
+    @Override
+    public Identifier toPhysicalTableName(Identifier name, JdbcEnvironment context) {
+        String upperCaseName = name.getText().toUpperCase();
+        return Identifier.toIdentifier(upperCaseName);
+    }
+
+    @Override
+    public Identifier toPhysicalColumnName(Identifier name, JdbcEnvironment context) {
+        String upperSnakeCaseName = name.getText()
+                .replaceAll("([a-z])([A-Z])", "$1_$2")
+                .toUpperCase();
+        return Identifier.toIdentifier(upperSnakeCaseName);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,10 @@ spring:
       mode: always
       schema-locations: data/database.sql
       data-locations: data/data.sql
+  jpa:
+    properties:
+      hibernate:
+        physical_naming_strategy: com.koliving.api.config.CustomNamingStrategy
 
 # Open API (swagger)
 springdoc:


### PR DESCRIPTION
entity 클래스와 database 테이블 간의 이름 매핑 규칙을 적용함

* physical naming strategy을 적용함
* Entity(Pascal Case)    ->  Table (UpperCase)
* property(camelCase) ->  Column (Upper snake case)