### PR TITLE
Feat: Email Confirmation Token entity

### DIFF
--- a/src/main/java/com/koliving/api/email/ConfirmationToken.java
+++ b/src/main/java/com/koliving/api/email/ConfirmationToken.java
@@ -31,7 +31,7 @@ public class ConfirmationToken {
     private LocalDateTime expiresAt;
 
     @Transient
-    @Value("${auth.email.validity-period:30}")
+    @Value("${spring.mail.properties.mail.auth.validity-period:30}")
     private long validityPeriod;
     private boolean isResended;
     private boolean isConfirmed;

--- a/src/main/java/com/koliving/api/email/ConfirmationToken.java
+++ b/src/main/java/com/koliving/api/email/ConfirmationToken.java
@@ -1,0 +1,51 @@
+package com.koliving.api.email;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Transient;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class ConfirmationToken {
+
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Id
+    private Integer id;
+    private String token;
+    private String email;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+    private LocalDateTime expiresAt;
+
+    @Transient
+    @Value("${auth.email.validity-period:30}")
+    private long validityPeriod;
+    private boolean isResended;
+    private boolean isConfirmed;
+
+    @Builder
+    public ConfirmationToken(String email) {
+        this.token = UUID.randomUUID().toString();
+        this.email = email;
+        this.expiresAt = LocalDateTime.now().plusMinutes(validityPeriod);
+        this.isResended = false;
+        this.isConfirmed = false;
+    }
+
+    public void confirmed() {
+        this.isConfirmed = true;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,9 @@ spring:
     properties:
       hibernate:
         physical_naming_strategy: com.koliving.api.config.CustomNamingStrategy
+  mail:
+    properties:
+      mail.auth.validity-period: 30
 
 # Open API (swagger)
 springdoc:


### PR DESCRIPTION
이메일 인증 발송시, 해당 토큰 관련 테이블을 생성하여 관리하기 위해 
`ConfirmationToken Entity`를 생성함

* 인증메일의 토큰 유효기간의 디폴트값은 30분
* `@Value` : 외부 환경파일을 통해 주입받을 수 있음