### PR TITLE
[Feat] UserService::saveTokenAndSendEmail

### DIFF
--- a/src/main/java/com/koliving/api/event/ConfirmationTokenCreatedEvent.java
+++ b/src/main/java/com/koliving/api/event/ConfirmationTokenCreatedEvent.java
@@ -1,0 +1,16 @@
+package com.koliving.api.event;
+
+import com.koliving.api.registeration.token.ConfirmationToken;
+import lombok.Getter;
+
+@Getter
+public class ConfirmationTokenCreatedEvent  {
+
+    private final String email;
+    private final String token;
+
+    public ConfirmationTokenCreatedEvent(ConfirmationToken savedToken) {
+        this.email = savedToken.getEmail();
+        this.token = savedToken.getToken();
+    }
+}

--- a/src/main/java/com/koliving/api/event/EventListener.java
+++ b/src/main/java/com/koliving/api/event/EventListener.java
@@ -1,0 +1,24 @@
+package com.koliving.api.event;
+
+import com.koliving.api.registeration.token.IConfirmationTokenService;
+import lombok.AllArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@AllArgsConstructor
+public class EventListener {
+
+    private final IConfirmationTokenService confirmationTokenService;
+
+    @Async
+    @TransactionalEventListener(
+        classes = ConfirmationTokenCreatedEvent.class,
+        phase = TransactionPhase.AFTER_COMMIT
+    )
+    public void onConfirmationTokenCreated(ConfirmationTokenCreatedEvent event) {
+        confirmationTokenService.sendEmail(event.getEmail(), event.getToken());
+    }
+}

--- a/src/main/java/com/koliving/api/user/IUserService.java
+++ b/src/main/java/com/koliving/api/user/IUserService.java
@@ -1,0 +1,8 @@
+package com.koliving.api.user;
+
+
+public interface IUserService {
+
+    void saveTokenAndSendEmail(String mail);
+
+}

--- a/src/main/java/com/koliving/api/user/UserService.java
+++ b/src/main/java/com/koliving/api/user/UserService.java
@@ -1,0 +1,28 @@
+package com.koliving.api.user;
+
+import com.koliving.api.event.ConfirmationTokenCreatedEvent;
+import com.koliving.api.registeration.token.ConfirmationToken;
+import com.koliving.api.registeration.token.IConfirmationTokenService;
+import lombok.AllArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@AllArgsConstructor
+public class UserService implements IUserService {
+
+    private final IConfirmationTokenService confirmationTokenService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Override
+    @Transactional
+    public void saveTokenAndSendEmail(String mail) {
+        ConfirmationToken confirmationToken = ConfirmationToken.builder()
+                .email(mail)
+                .build();
+
+        ConfirmationToken savedToken = confirmationTokenService.saveToken(confirmationToken);
+        eventPublisher.publishEvent(new ConfirmationTokenCreatedEvent(savedToken));
+    }
+}


### PR DESCRIPTION
saveTokenAndSendEmail 메서드를 생성하였음

* 이메일 인증 시나리오
  * confirmationToken 테이블 : 이메일 인증관련 토큰을 포함한 행 추가
  * 인증 이메일 발송

* 이메일 인증 요청 시, 위의 두 behavior는 트랜잭션으로 묶어 진행해야 함
* 두번째 액션인 '인증 이메일 발송'은 외부 인프라스트럭쳐 
* 첫번째 액션에서 익셉션이 발생하더라도 롤백과 무관하게 이메일을 전송함

* `@TransactionEventListener`를 활용하여 트랜잭션 상태에 따른이벤트를 처리하도록 구현
* 첫번째 액션이 정상 커밋되는 경우에만 이벤트가 발생하며, 해당 이벤트 리스너에 의해 이메일이 발송됨