### PR TITLE
[Refactor] ConfirmationTokenService - time

### DIFF
--- a/src/main/java/com/koliving/api/clock/Clock.java
+++ b/src/main/java/com/koliving/api/clock/Clock.java
@@ -1,0 +1,7 @@
+package com.koliving.api.clock;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class Clock implements IClock {
+}

--- a/src/main/java/com/koliving/api/clock/IClock.java
+++ b/src/main/java/com/koliving/api/clock/IClock.java
@@ -1,0 +1,9 @@
+package com.koliving.api.clock;
+
+import java.time.LocalDateTime;
+
+public interface IClock {
+    default LocalDateTime now() {
+        return LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/koliving/api/registeration/token/ConfirmationTokenService.java
+++ b/src/main/java/com/koliving/api/registeration/token/ConfirmationTokenService.java
@@ -1,5 +1,6 @@
 package com.koliving.api.registeration.token;
 
+import com.koliving.api.clock.IClock;
 import com.koliving.api.email.IEmailService;
 import com.koliving.api.email.MailType;
 import org.springframework.beans.factory.annotation.Value;
@@ -14,16 +15,19 @@ public class ConfirmationTokenService implements IConfirmationTokenService {
 
     private final ConfirmationTokenRepository confirmationTokenRepository;
     private final IEmailService emailSender;
+    private final IClock clock;
     private String origin;
     private String currentVersion;
 
     public ConfirmationTokenService(ConfirmationTokenRepository confirmationTokenRepository,
                                     IEmailService emailSender,
+                                    IClock clock,
                                     @Value("${server.origin:http://localhost:8080}") String origin,
                                     @Value("${server.current-version:v1}") String currentVersion
                                     ) {
         this.confirmationTokenRepository = confirmationTokenRepository;
         this.emailSender = emailSender;
+        this.clock = clock;
         this.origin = origin;
         this.currentVersion = currentVersion;
     }

--- a/src/main/java/com/koliving/api/registeration/token/ConfirmationTokenService.java
+++ b/src/main/java/com/koliving/api/registeration/token/ConfirmationTokenService.java
@@ -87,7 +87,7 @@ public class ConfirmationTokenService implements IConfirmationTokenService {
     }
 
     private boolean isExpired(LocalDateTime expiredAt) {
-        return expiredAt.isBefore(LocalDateTime.now());
+        return expiredAt.isBefore(clock.now());
     }
 
     private void confirmToken(ConfirmationToken confirmationToken) {


### PR DESCRIPTION
유효기간 만료 여부를 확인하는 로직에서, 제어할 수 없는 값을 의존하고 있음
* LocalDateTime.now() 는 항상 다름
* 실행할 때마다 항상 결과가 같게 하여 테스트할 수 있도록 설계해야 함
* 제어할 수 없는 값을 외부에서 주입받도록 리팩토링하였음

* 현재 날짜를 리턴하는 서비스 빈 생성 및 주입