### PR TITLE
[Refactor] ConfirmationToken : validityPeriod

### DIFF
--- a/src/main/java/com/koliving/api/registeration/token/ConfirmationToken.java
+++ b/src/main/java/com/koliving/api/registeration/token/ConfirmationToken.java
@@ -9,7 +9,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
-import org.springframework.beans.factory.annotation.Value;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -31,13 +30,12 @@ public class ConfirmationToken {
     private LocalDateTime expiresAt;
 
     @Transient
-    @Value("${spring.mail.properties.mail.auth.validity-period:30}")
     private long validityPeriod;
     private boolean isResended;
     private boolean isConfirmed;
 
     @Builder
-    public ConfirmationToken(String email) {
+    public ConfirmationToken(String email, long validityPeriod) {
         this.token = UUID.randomUUID().toString();
         this.email = email;
         this.expiresAt = LocalDateTime.now().plusMinutes(validityPeriod);

--- a/src/main/java/com/koliving/api/registeration/token/ConfirmationTokenService.java
+++ b/src/main/java/com/koliving/api/registeration/token/ConfirmationTokenService.java
@@ -18,23 +18,34 @@ public class ConfirmationTokenService implements IConfirmationTokenService {
     private final IClock clock;
     private String origin;
     private String currentVersion;
+    private long validityPeriod;
 
     public ConfirmationTokenService(ConfirmationTokenRepository confirmationTokenRepository,
                                     IEmailService emailSender,
                                     IClock clock,
                                     @Value("${server.origin:http://localhost:8080}") String origin,
-                                    @Value("${server.current-version:v1}") String currentVersion
+                                    @Value("${server.current-version:v1}") String currentVersion,
+                                    @Value("${spring.mail.properties.mail.auth.validity-period:30}") long validityPeriod
                                     ) {
         this.confirmationTokenRepository = confirmationTokenRepository;
         this.emailSender = emailSender;
         this.clock = clock;
         this.origin = origin;
         this.currentVersion = currentVersion;
+        this.validityPeriod = validityPeriod;
     }
 
     @Override
     public Optional<ConfirmationToken> getToken(String token) {
         return confirmationTokenRepository.findByToken(token);
+    }
+
+    @Override
+    public ConfirmationToken createToken(String email) {
+        return ConfirmationToken.builder()
+                .email(email)
+                .validityPeriod(validityPeriod)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/koliving/api/registeration/token/IConfirmationTokenService.java
+++ b/src/main/java/com/koliving/api/registeration/token/IConfirmationTokenService.java
@@ -6,6 +6,8 @@ public interface IConfirmationTokenService {
 
     Optional<ConfirmationToken> getToken(String token);
 
+    ConfirmationToken createToken(String email);
+
     ConfirmationToken saveToken(ConfirmationToken token);
 
     void sendEmail(String mail, String token);


### PR DESCRIPTION
transient한 멤버변수 `validityPeriod` 의 환경변수 주입을 삭제하고,
service 레이어에서 생성시에 주입하도록 구현함