### PR TITLE
[Refactor] Add MailException catch block

### DIFF
--- a/src/main/java/com/koliving/api/email/EmailService.java
+++ b/src/main/java/com/koliving/api/email/EmailService.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.mail.MailParseException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.scheduling.annotation.Async;
@@ -63,8 +64,8 @@ public class EmailService implements IEmailService {
 
             mailSender.send(mimeMessage);
         } catch (MessagingException e) {
-            log.error("failed to send email", e);
-            throw new IllegalStateException("failed to send email");
+            log.error("failed to generate email", e);
+            throw new MailParseException("failed to generate email", e);
         }
     }
 }

--- a/src/main/java/com/koliving/api/email/EmailService.java
+++ b/src/main/java/com/koliving/api/email/EmailService.java
@@ -7,7 +7,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.mail.MailException;
 import org.springframework.mail.MailParseException;
+import org.springframework.mail.MailSendException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.scheduling.annotation.Async;
@@ -66,6 +68,9 @@ public class EmailService implements IEmailService {
         } catch (MessagingException e) {
             log.error("failed to generate email", e);
             throw new MailParseException("failed to generate email", e);
+        } catch (MailException e) {
+            log.error("failed to send email", e);
+            throw new MailSendException("Failed to send email", e);
         }
     }
 }


### PR DESCRIPTION
* MessagingException은 MimeMessage를 생성중에 발생하는 예외
  * MessagingException는 Checked Exception임
  * 메일 생성 시에, 필요한 인자를 런타임에서 받음
  * 스프링 커스텀 예외이자 RuntimeException 구현체인 `MailParseException`로 교체
  * 추후 전역적으로 ExceptionHandling 을 위해 사용하였음

