### PR TITLE
[Feat] Security : user

### DIFF
--- a/src/main/java/com/koliving/api/user/User.java
+++ b/src/main/java/com/koliving/api/user/User.java
@@ -12,10 +12,12 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.Collections;
 
 @Getter
 @NoArgsConstructor
@@ -36,6 +38,9 @@ public class User implements UserDetails {
     private String description;
 
     @Enumerated(EnumType.STRING)
+    private UserRole userRole;
+
+    @Enumerated(EnumType.STRING)
     private SignUpStatus signUpStatus;
 
     private boolean bEnabled;
@@ -51,13 +56,17 @@ public class User implements UserDetails {
     public User(String email) {
         this.email = email;
         this.signUpStatus = SignUpStatus.PASSWORD_VERIFICATION_PENDING;
+        this.userRole = UserRole.USER;
         this.bEnabled = true;
         this.bLocked = false;
     }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return null;
+        String role = userRole.name();
+        SimpleGrantedAuthority authority = new SimpleGrantedAuthority(role);
+
+        return Collections.singletonList(authority);
     }
 
     @Override

--- a/src/main/java/com/koliving/api/user/User.java
+++ b/src/main/java/com/koliving/api/user/User.java
@@ -11,13 +11,16 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 
 @Getter
 @NoArgsConstructor
 @Entity
-public class User {
+public class User implements UserDetails {
 
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Id
@@ -35,6 +38,9 @@ public class User {
     @Enumerated(EnumType.STRING)
     private SignUpStatus signUpStatus;
 
+    private boolean bEnabled;
+    private boolean bLocked;
+
     @CreationTimestamp
     private LocalDateTime createdDate;
 
@@ -45,6 +51,39 @@ public class User {
     public User(String email) {
         this.email = email;
         this.signUpStatus = SignUpStatus.PASSWORD_VERIFICATION_PENDING;
+        this.bEnabled = true;
+        this.bLocked = false;
     }
 
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return bEnabled;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return !bLocked;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        // TODO : need field related to user expiration
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        // TODO : need field related to password expiration
+        return true;
+    }
 }

--- a/src/main/java/com/koliving/api/user/UserRole.java
+++ b/src/main/java/com/koliving/api/user/UserRole.java
@@ -1,0 +1,5 @@
+package com.koliving.api.user;
+
+public enum UserRole {
+    USER
+}

--- a/src/main/java/com/koliving/api/user/UserService.java
+++ b/src/main/java/com/koliving/api/user/UserService.java
@@ -5,15 +5,25 @@ import com.koliving.api.token.ConfirmationToken;
 import com.koliving.api.token.IConfirmationTokenService;
 import lombok.AllArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @AllArgsConstructor
-public class UserService implements IUserService {
+public class UserService implements IUserService, UserDetailsService {
 
+    private final UserRepository userRepository;
     private final IConfirmationTokenService confirmationTokenService;
     private final ApplicationEventPublisher eventPublisher;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) {
+        return userRepository.findByEmail(email).orElseThrow(() ->
+                new UsernameNotFoundException(String.format("User with email %s not found", email)));
+    }
 
     @Override
     @Transactional
@@ -22,4 +32,5 @@ public class UserService implements IUserService {
         ConfirmationToken savedToken = confirmationTokenService.saveToken(newToken);
         eventPublisher.publishEvent(new ConfirmationTokenCreatedEvent(savedToken));
     }
+
 }


### PR DESCRIPTION
User 인증중에 security 컴포넌트와의 협력을 위해 
(인증담당 구현체인 `DaoAuthenticationProvider`가 User 도메인에 의존하도록)

* `User`: UserDetails 인터페이스 상속
  * getAuthorities()                                  구현 
     * (Enum) UserRole 생성 
     * UserRole 필드 추가
  * isEnabled(), isAccountNonLocked() 구현
     * bEnabled 필드 추가
     * bLocked 필드 추가
* `UserService`: UserDetailsService 인터페이스 상속
  * loadUserByUsername() 구현