### PR TITLE
[Feat] Add jaxb dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,9 @@ dependencies {
     compileOnly    'jakarta.servlet:jakarta.servlet-api:5.0.0'
     runtimeOnly    'org.springframework.boot:spring-boot-starter-tomcat'
     runtimeOnly    'mysql:mysql-connector-java:8.0.22'
+
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
+    implementation 'javax.xml.bind:jaxb-api:2.3.1'
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
@@ -25,7 +28,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
-    implementation 'io.jsonwebtoken:jjwt:0.9.1'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     annotationProcessor 'org.projectlombok:lombok:1.18.20'


### PR DESCRIPTION
* `NoClassDefFoundError` 에러 발생
* jwt 파싱을 위한 XML 직렬화 의존성인 jaxb를 추가함
* jjwt 라이브러리로 jwt 생성시에 해당 라이브러리의 클래스 필요
* java 11 이후로, java EE API가 JDK에 제외되었음
* 해당 의존성을 저장소에서 명시적으로 당겨와야 함