### PR TITLE
[Refactor] Modify access modifier : jwtprovider's getEmail()

### DIFF
--- a/src/main/java/com/koliving/api/provider/JwtProvider.java
+++ b/src/main/java/com/koliving/api/provider/JwtProvider.java
@@ -128,12 +128,15 @@ public class JwtProvider {
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 
-    private Claims getClaimsFormToken(String token) {
-        return Jwts.parser().setSigningKey(DatatypeConverter.parseBase64Binary(secret)).parseClaimsJws(token).getBody();
-    }
-
-    private String getEmail(String token) {
+    public String getEmail(String token) {
         Claims claim = getClaimsFormToken(token);
         return (String) claim.get("email");
+    }
+
+    private Claims getClaimsFormToken(String token) {
+        return Jwts.parser()
+                .setSigningKey(DatatypeConverter.parseBase64Binary(secret))
+                .parseClaimsJws(token)
+                .getBody();
     }
 }


### PR DESCRIPTION
접근제어자를 private -> public으로 수정하였음

* secured API 요청시에 컨트롤러 메소드에서 커스텀 애노테이션과
* 이에 매칭되는 커스텀 method parameter resolver 구현을 통해 email을 얻기 위해
