### PR TITLE
[Refactor] jwtAuthenticationFilter - jwt dependencies

### DIFF
--- a/src/main/java/com/koliving/api/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/koliving/api/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.koliving.api.filter;
 
 import com.koliving.api.provider.JwtProvider;
+import com.koliving.api.token.IJwtService;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureException;
@@ -22,23 +23,24 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     public static final String BEARER_PREFIX = "Bearer ";
     private final JwtProvider jwtProvider;
+    private final IJwtService jwtService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        String token = null;
+        String accessToken = null;
         try {
-            token = resolveToken(request);
+            accessToken = resolveToken(request);
         } catch (RuntimeException e) {
             setResponse(response, e.getMessage());
         }
 
         try {
-            jwtProvider.validateAccessToken(token);
+            jwtProvider.validateToken(accessToken);
         } catch (ExpiredJwtException | MalformedJwtException | SignatureException | UnsupportedJwtException e) {
             setResponse(response, e.getMessage());
         }
 
-        Authentication authentication = jwtProvider.getAuthentication(token);
+        Authentication authentication = jwtService.getAuthentication(accessToken);
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
         filterChain.doFilter(request, response);

--- a/src/main/java/com/koliving/api/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/koliving/api/filter/JwtAuthenticationFilter.java
@@ -2,10 +2,6 @@ package com.koliving.api.filter;
 
 import com.koliving.api.provider.JwtProvider;
 import com.koliving.api.token.IJwtService;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.SignatureException;
-import io.jsonwebtoken.UnsupportedJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -28,15 +24,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String accessToken = null;
-        try {
-            accessToken = resolveToken(request);
-        } catch (RuntimeException e) {
-            setResponse(response, e.getMessage());
-        }
 
         try {
+            accessToken = resolveToken(request);
             jwtProvider.validateToken(accessToken);
-        } catch (ExpiredJwtException | MalformedJwtException | SignatureException | UnsupportedJwtException e) {
+        } catch (RuntimeException e) {
             setResponse(response, e.getMessage());
         }
 


### PR DESCRIPTION
1. 인증객체를 얻어오기 위한 메서드가 jwtService로 이관되었으므로, 해당 의존성을 주입받는다

2. 헤더 예외, jwt 예외에 맞게 두 개의 try-catch 블록으로 나뉘어져 있었음
* 코드 정리가 되어있지 않아 가독성이 좋지 않고 
* catch 블록의 처리 과정이 같고 
* callee의 메서드를 추적하는데 문맥을 파악하는데 어려움이 없다 판단함
* 결론 : 한개 블록으로 묶음