### PR TITLE
[Refactor] delete redis repository configuration

### DIFF
--- a/src/main/java/com/koliving/api/config/RedisConfig.java
+++ b/src/main/java/com/koliving/api/config/RedisConfig.java
@@ -6,11 +6,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
-@EnableRedisRepositories
 public class RedisConfig {
 
     @Value("${spring.data.redis.host}")

--- a/src/main/java/com/koliving/api/token/refresh/RefreshToken.java
+++ b/src/main/java/com/koliving/api/token/refresh/RefreshToken.java
@@ -2,14 +2,10 @@ package com.koliving.api.token.refresh;
 
 import lombok.Builder;
 import lombok.Getter;
-import org.springframework.data.annotation.Id;
-import org.springframework.data.redis.core.RedisHash;
 
 @Getter
-@RedisHash(value = "RefreshToken", timeToLive = 60*60*24*30) // 1 month (30 days)
 public class RefreshToken {
 
-    @Id
     private String email;
     private String refreshToken;
 

--- a/src/main/java/com/koliving/api/token/refresh/RefreshTokenRepository.java
+++ b/src/main/java/com/koliving/api/token/refresh/RefreshTokenRepository.java
@@ -1,6 +1,0 @@
-package com.koliving.api.token.refresh;
-
-import org.springframework.data.repository.CrudRepository;
-
-public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
-}


### PR DESCRIPTION
RedisRepository 로 사용시 
* hash 자료구조의 secondary-index 관련 데이터 연산 비용이 많이 듬 (데이터 일관성 보장 때문)
* refreshtoken 값에서 claim을 추출하여 value값으로 field를 얻을 수 있으므로 secondary-index 사용보다 경제적이라 판단함
* redis를 캐시 저장소로 사용하는데 있어, redistemplate로 연산할 정도의 간단한 연산만 필요로 함

이같은 결정을 내리고 repository 관련 설정을 내림