### PR TITLE
[Feat] Add distributedLock AOP annotation using redisson

### DIFF
--- a/src/main/java/com/koliving/api/annotation/AopForTransaction.java
+++ b/src/main/java/com/koliving/api/annotation/AopForTransaction.java
@@ -1,0 +1,15 @@
+package com.koliving.api.annotation;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class AopForTransaction {
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+    }
+}

--- a/src/main/java/com/koliving/api/annotation/CustomSpringELParser.java
+++ b/src/main/java/com/koliving/api/annotation/CustomSpringELParser.java
@@ -1,0 +1,19 @@
+package com.koliving.api.annotation;
+
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+public class CustomSpringELParser {
+
+    public static Object getDynamicValue(String[] parameterNames, Object[] args, String key) {
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return parser.parseExpression(key).getValue(context, Object.class);
+    }
+}

--- a/src/main/java/com/koliving/api/annotation/DistributedLock.java
+++ b/src/main/java/com/koliving/api/annotation/DistributedLock.java
@@ -1,0 +1,17 @@
+package com.koliving.api.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+
+public @interface DistributedLock {
+    String key();
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+    long waitTime() default 5L;
+    long leaseTime() default 3L;
+}

--- a/src/main/java/com/koliving/api/annotation/DistributedLockAop.java
+++ b/src/main/java/com/koliving/api/annotation/DistributedLockAop.java
@@ -1,0 +1,50 @@
+package com.koliving.api.annotation;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class DistributedLockAop {
+    private final RedissonClient redissonClient;
+    private final AopForTransaction aopForTransaction;
+    private static final String REDISSION_LOCK_PREFIX = "LOCK:";
+
+    @Around("@annotation(com.koliving.api.annotation.DistributedLock)")
+    public Object lock(final ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
+
+        String key = REDISSION_LOCK_PREFIX + CustomSpringELParser.getDynamicValue(signature.getParameterNames(), joinPoint.getArgs(), distributedLock.key());
+        RLock rLock = redissonClient.getLock(key);
+
+        try {
+            boolean available = rLock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(), distributedLock.timeUnit());
+            if (!available) {
+                return false;
+            }
+
+            return aopForTransaction.proceed(joinPoint);
+        } catch (InterruptedException e) {
+            throw e;
+        } finally {
+            try {
+                rLock.unlock();
+            } catch (IllegalMonitorStateException e) {
+                log.error("Redisson Lock Already Unlock. " + method.getName() + " " + key);
+            }
+        }
+    }
+}


### PR DESCRIPTION
* (annotation) DistributedLock : 해당 에노테이션이 붙은 메서드 연산은 분산락으로 실행되므로 동시성이 보장됨
* DistributedLockAop : DistributedLock 애노테이션이 붙은 메서드의 시작과 끝에 일어날 연산을 락 획득 및 반환으로 작성함
* CustomerSpringELParser : 획득할 Lock의 이름을 DistributedLock 애노테이션의 key 속성값의 SPEL 표현식의 결과가 되도록 하는 parser 작성함
* AopForTransaction : JoinPoint를 파라미터로 넘겨 해당 함수의 트랜잭션 전략이 Propagation.REQUIRES_NEW로 적용되도록 하기 위해 작성함 (별도의 트랜잭션으로 처리해서 커밋 후 unlock 되도록 해야 동시성 이슈가 없음)


출처 : [(https://helloworld.kurly.com/blog/distributed-redisson-lock/)]