### PR TITLE
feat: set jvm timezone to utc

### DIFF
--- a/src/main/java/com/koliving/api/KolivingApplication.java
+++ b/src/main/java/com/koliving/api/KolivingApplication.java
@@ -1,8 +1,11 @@
 package com.koliving.api;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+
+import java.util.TimeZone;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan("com.koliving.api.properties")
@@ -12,4 +15,8 @@ public class KolivingApplication {
         SpringApplication.run(KolivingApplication.class, args);
     }
 
+    @PostConstruct
+    void started() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    }
 }


### PR DESCRIPTION
글로벌 서비스 제공을 위해 
- 날짜 데이터는 mysql에 utc timezone 형식으로 읽도록 jvm timezone 설정
