### PR TITLE
refactor: modelmapper gendercode

### DIFF
--- a/src/main/java/com/koliving/api/config/ModelMapperConfig.java
+++ b/src/main/java/com/koliving/api/config/ModelMapperConfig.java
@@ -1,8 +1,7 @@
 package com.koliving.api.config;
 
-import com.koliving.api.user.Gender;
-import org.modelmapper.AbstractConverter;
-import org.modelmapper.Converter;
+import com.koliving.api.dto.ProfileDto;
+import com.koliving.api.user.User;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.convention.MatchingStrategies;
 import org.springframework.context.annotation.Bean;
@@ -19,19 +18,9 @@ public class ModelMapperConfig {
                 .setFieldAccessLevel(org.modelmapper.config.Configuration.AccessLevel.PRIVATE)
                 .setFieldMatchingEnabled(true);
 
-        Converter<Integer, Gender> intToGender = new AbstractConverter<Integer, Gender>() {
-            @Override
-            protected Gender convert(Integer source) {
-            return switch (source) {
-                case 0 -> Gender.MALE;
-                case 1 -> Gender.FEMALE;
-                case 2 -> Gender.OTHER;
-                default -> throw new IllegalStateException("Unexpected value: " + source);
-            };
-            }
-        };
-
-        modelMapper.addConverter(intToGender);
+        modelMapper.typeMap(ProfileDto.class, User.class).addMappings(mapper -> {
+            mapper.map(ProfileDto::toGender, User::setGender);
+        });
 
         return modelMapper;
     }

--- a/src/main/java/com/koliving/api/dto/ProfileDto.java
+++ b/src/main/java/com/koliving/api/dto/ProfileDto.java
@@ -1,5 +1,6 @@
 package com.koliving.api.dto;
 
+import com.koliving.api.user.Gender;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -26,7 +27,7 @@ public class ProfileDto {
     @NotNull
     @Range(min = 0L, max=2L)
     @Schema(description = "성별 (0-남, 1-여, 2-OTHER)", allowableValues = {"0", "1", "2"}, example = "0")
-    private int genderCode;
+    private Integer genderCode;
 
     @NotNull
     @Past
@@ -38,4 +39,8 @@ public class ProfileDto {
     @Size(min = 0, max =500)
     @Schema(description = "자기소개 (1000byte 까지)", maxLength = 500, example = "hello koliving")
     private String description;
+
+    public Gender toGender() {
+        return Gender.findByCode(genderCode);
+    }
 }

--- a/src/main/java/com/koliving/api/user/Gender.java
+++ b/src/main/java/com/koliving/api/user/Gender.java
@@ -2,6 +2,9 @@ package com.koliving.api.user;
 
 import lombok.Getter;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Getter
 public enum Gender {
     MALE(0), FEMALE(1), OTHER(2);
@@ -10,5 +13,17 @@ public enum Gender {
 
     Gender(int code) {
         this.code = code;
+    }
+
+    private final static Map<Integer, Gender> map;
+    static {
+        map = new HashMap<>();
+        for (Gender gender : Gender.values()) {
+            map.put(gender.getCode(), gender);
+        }
+    }
+
+    public static Gender findByCode(int code) {
+        return map.get(code);
     }
 }

--- a/src/main/java/com/koliving/api/user/User.java
+++ b/src/main/java/com/koliving/api/user/User.java
@@ -9,10 +9,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.Collection;
-import java.util.Collections;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -26,6 +22,11 @@ import org.hibernate.annotations.UpdateTimestamp;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.Collections;
 
 @Entity(name = "TB_USER")
 @DynamicInsert
@@ -89,6 +90,10 @@ public class User implements UserDetails {
     public void setPassword(String password) {
         this.password = password;
         this.signUpStatus = SignUpStatus.PROFILE_INFORMATION_PENDING;
+    }
+
+    public void setGender(Gender gender) {
+        this.gender = gender;
     }
 
     public void completeSignUp() {


### PR DESCRIPTION
- 클라이언트로부터 전달받은 gendercode를 gender (enum)으로 매핑하는 구현 변경
- 기존 converter의 기능 동작이 정상적이지 못하여, typeMap을 이용하여 구현함
- 이로 인해 user의 gender 관련 setter, gender의 findByCode 함수가 추가됨