### PR TITLE
Refactor: return redirect url by front

### DIFF
--- a/src/main/java/com/koliving/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/koliving/api/GlobalExceptionHandler.java
@@ -16,7 +16,6 @@ import com.koliving.api.user.SignUpStatus;
 import com.koliving.api.user.User;
 import com.koliving.api.user.UserService;
 import com.koliving.api.utils.HttpUtils;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -62,7 +61,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(value = ConfirmationTokenException.class)
-    public ResponseEntity<ResponseDto<ConfirmationTokenErrorDto>> handleAuthException(ConfirmationTokenException e, HttpServletRequest request, Locale locale) {
+    public ResponseEntity<ResponseDto<ConfirmationTokenErrorDto>> handleAuthException(ConfirmationTokenException e, Locale locale) {
         String messageKey = e.getMessage();
         String errorMessage = messageSource.getMessage(messageKey, null, locale);
 
@@ -78,7 +77,7 @@ public class GlobalExceptionHandler {
             case "authenticated_confirmation_token" -> {
                 status = HttpStatus.UNAUTHORIZED;
                 ConfirmationToken confirmationToken = confirmationTokenService.get(e.getToken()).get();
-                redirectPath = getConfirmationTokenRedirectUrl(confirmationToken.getTokenType(), email, request);
+                redirectPath = getConfirmationTokenRedirectUrl(confirmationToken.getTokenType(), email);
             }
         }
 
@@ -121,9 +120,9 @@ public class GlobalExceptionHandler {
         return httpUtils.getFrontUrl(path);
     }
 
-    private String getConfirmationTokenRedirectUrl(ConfirmationTokenType tokenType, String email, HttpServletRequest request) {
+    private String getConfirmationTokenRedirectUrl(ConfirmationTokenType tokenType, String email) {
         if (tokenType == SIGN_UP) {
-            return getSignUpRedirectUrl(email, request);
+            return getSignUpRedirectUrl(email);
         } else if (tokenType == RESET_PASSWORD) {
             return getRedirectUrl(tokenType.getRedirectPath());
         }
@@ -131,7 +130,7 @@ public class GlobalExceptionHandler {
         return null;
     }
 
-    private String getSignUpRedirectUrl(String email, HttpServletRequest request) {
+    private String getSignUpRedirectUrl(String email) {
         User user = (User) userService.loadUserByUsername(email);
         SignUpStatus currentSignUpStatus = user.getSignUpStatus();
 

--- a/src/main/java/com/koliving/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/koliving/api/GlobalExceptionHandler.java
@@ -73,7 +73,7 @@ public class GlobalExceptionHandler {
         switch (messageKey) {
             case "ungenerated_confirmation_token", "expired_confirmation_token" -> {
                 status = HttpStatus.BAD_REQUEST;
-                redirectPath = httpUtils.getCurrentVersionPath("login");
+                redirectPath = getRedirectUrl("/login");
             }
             case "authenticated_confirmation_token" -> {
                 status = HttpStatus.UNAUTHORIZED;
@@ -117,11 +117,15 @@ public class GlobalExceptionHandler {
         return ErrorResponse.valueOf(e.getError());
     }
 
+    private String getRedirectUrl(String path) {
+        return httpUtils.getFrontUrl(path);
+    }
+
     private String getConfirmationTokenRedirectUrl(ConfirmationTokenType tokenType, String email, HttpServletRequest request) {
         if (tokenType == SIGN_UP) {
             return getSignUpRedirectUrl(email, request);
         } else if (tokenType == RESET_PASSWORD) {
-            return httpUtils.getCurrentVersionPath("auth/reset-password");
+            return getRedirectUrl(tokenType.getRedirectPath());
         }
 
         return null;
@@ -131,7 +135,7 @@ public class GlobalExceptionHandler {
         User user = (User) userService.loadUserByUsername(email);
         SignUpStatus currentSignUpStatus = user.getSignUpStatus();
 
-        return currentSignUpStatus.getRedirectUri(httpUtils, request);
+        return getRedirectUrl(currentSignUpStatus.getRedirectPath());
     }
 
     private String getErrorMessage(RuntimeException e, Locale locale) {

--- a/src/main/java/com/koliving/api/user/SignUpStatus.java
+++ b/src/main/java/com/koliving/api/user/SignUpStatus.java
@@ -1,7 +1,5 @@
 package com.koliving.api.user;
 
-import com.koliving.api.utils.HttpUtils;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.Getter;
 
 @Getter
@@ -15,15 +13,5 @@ public enum SignUpStatus {
 
     SignUpStatus(String redirectPath) {
         this.redirectPath = redirectPath;
-    }
-
-    public String getRedirectUri(HttpUtils httpUtils, HttpServletRequest request) {
-        if (this == PASSWORD_VERIFICATION_PENDING || this == PROFILE_INFORMATION_PENDING) {
-            return httpUtils.getRedirectUri(request, getRedirectPath());
-        } else if (this == COMPLETED) {
-            return httpUtils.getCurrentVersionPath(getRedirectPath());
-        }
-
-        return null;
     }
 }

--- a/src/main/java/com/koliving/api/user/SignUpStatus.java
+++ b/src/main/java/com/koliving/api/user/SignUpStatus.java
@@ -7,19 +7,21 @@ import lombok.Getter;
 @Getter
 public enum SignUpStatus {
 
-    PASSWORD_VERIFICATION_PENDING("/password"), PROFILE_INFORMATION_PENDING("/profile"), COMPLETED("/login");
+    PASSWORD_VERIFICATION_PENDING("/signup/step2"),
+    PROFILE_INFORMATION_PENDING("/signup/step2"),
+    COMPLETED("/login");
 
-    private final String redirectResourcePath;
+    private final String redirectPath;
 
-    SignUpStatus(String redirectResourcePath) {
-        this.redirectResourcePath = redirectResourcePath;
+    SignUpStatus(String redirectPath) {
+        this.redirectPath = redirectPath;
     }
 
     public String getRedirectUri(HttpUtils httpUtils, HttpServletRequest request) {
         if (this == PASSWORD_VERIFICATION_PENDING || this == PROFILE_INFORMATION_PENDING) {
-            return httpUtils.getRedirectUri(request, getRedirectResourcePath());
+            return httpUtils.getRedirectUri(request, getRedirectPath());
         } else if (this == COMPLETED) {
-            return httpUtils.getCurrentVersionPath(getRedirectResourcePath());
+            return httpUtils.getCurrentVersionPath(getRedirectPath());
         }
 
         return null;


### PR DESCRIPTION
confirmation token exception handling
- confirmation token type 변수명 변경 및 값 수정
- confirmation token type method 삭제
- globalExceptionHandler에서 httpUtils의 getFrontUrl()에 위임하여 프론트 기준 url으로 응답